### PR TITLE
change(data-types/encodable): `Future` が自動で中括弧 `{}` を付けない

### DIFF
--- a/src/data-types/encodable/future.ts
+++ b/src/data-types/encodable/future.ts
@@ -27,7 +27,7 @@ export default class Future extends Base implements Encodable {
   }
 
   toSurql(): string {
-    return "<future>{" + this.block + "}";
+    return "<future>" + this.block;
   }
 
   toPlainObject(): {

--- a/tests/medium/data-types/cbor.test.ts
+++ b/tests/medium/data-types/cbor.test.ts
@@ -116,7 +116,6 @@ for (const { suite, fmt, url, ver, Surreal } of surreal) {
         ]),
         decimal: new Decimal("3.1415926"),
         duration: new Duration("1y2w3d4h5m6s7ms8us9ns"),
-        future: new Future("string::concat('Hello', ' ', 'World')"),
         geometryPoint,
         geometryLine,
         geometryPolygon,
@@ -147,7 +146,6 @@ for (const { suite, fmt, url, ver, Surreal } of surreal) {
       };
       const expected = {
         ...input,
-        future: "Hello World",
       };
 
       {
@@ -223,6 +221,33 @@ for (const { suite, fmt, url, ver, Surreal } of surreal) {
           new Thing("foo", new Range([new BoundIncluded(1), null])),
           new Thing("foo", new Range([null, new BoundExcluded(3)])),
           new Thing("foo", new Range([null, null])),
+        ]);
+    });
+
+    // https://github.com/surrealdb/surrealdb/pull/5050
+    // >2.0.4 で変更予定。
+    test("Futrue", async c => {
+      if (!(ver.gt("2.0.4") || (ver.eq("2.0.4") && ver.nightly()))) {
+        c.skip();
+      }
+
+      await using db = new Surreal();
+      await db.connect(url());
+      await db.signin({ user: "root", pass: "root" });
+
+      await expect(
+        db.query(
+          /* surql */ `
+          RETURN $future;
+        `,
+          {
+            future: new Future("{ string::concat('Hello', ' ', 'World') }"),
+          },
+        ),
+      )
+        .resolves
+        .toStrictEqual([
+          "Hello World",
         ]);
     });
   });

--- a/tests/small/data-types/future.test.ts
+++ b/tests/small/data-types/future.test.ts
@@ -3,45 +3,45 @@ import { toSurql } from "@tai-kun/surrealdb/utils";
 import { expect, test } from "vitest";
 
 test(".block", () => {
-  const f = new Future("time::now()");
+  const f = new Future("{ time::now() }");
 
-  expect(f.block).toBe("time::now()");
+  expect(f.block).toBe("{ time::now() }");
 });
 
 test(".toString()", () => {
-  const f = new Future("time::now()");
+  const f = new Future("{ time::now() }");
 
-  expect(f.toString()).toBe("time::now()");
+  expect(f.toString()).toBe("{ time::now() }");
 });
 
 test(".toJSON()", () => {
-  const f = new Future("time::now()");
+  const f = new Future("{ time::now() }");
 
-  expect(f.toJSON()).toBe("time::now()");
+  expect(f.toJSON()).toBe("{ time::now() }");
 });
 
 test(".toSurql()", () => {
-  const f = new Future("time::now()");
+  const f = new Future("{ time::now() }");
 
-  expect(f.toSurql()).toBe("<future>{time::now()}");
+  expect(f.toSurql()).toBe("<future>{ time::now() }");
 });
 
 test(".toPlainObject()", () => {
-  const f = new Future("time::now()");
+  const f = new Future("{ time::now() }");
 
   expect(f.toPlainObject()).toStrictEqual({
-    block: "time::now()",
+    block: "{ time::now() }",
   });
 });
 
 test(".surql()", () => {
   const foo = "foo";
   const rid = new Thing("person", "tai-kun");
-  const future = new Future(Future.surql`
+  const future = new Future(Future.surql`{
     LET $a = ${foo} + ${Future.raw("'-'")};
     LET $b = type::string(${rid});
     string::concat($a, $b)
-  `);
+  }`);
 
   expect(future.toSurql()).toBe(`<future>{
     LET $a = 'foo' + '-';
@@ -53,11 +53,11 @@ test(".surql()", () => {
 test(".surql() なし", () => {
   const foo = "foo";
   const rid = new Thing("person", "tai-kun");
-  const future = new Future(/*surql*/ `
+  const future = new Future(/*surql*/ `{
     LET $a = ${toSurql(foo)} + ${"'-'"};
     LET $b = type::string(${rid.toSurql()});
     string::concat($a, $b)
-  `);
+  }`);
 
   expect(future.toSurql()).toBe(`<future>{
     LET $a = 'foo' + '-';
@@ -69,7 +69,7 @@ test(".surql() なし", () => {
 test(".clone()", () => {
   class MyFuture extends Future {}
 
-  const object = new MyFuture("time::now()");
+  const object = new MyFuture("{ time::now() }");
   const cloned = object.clone();
 
   expect(cloned).not.toBe(object);


### PR DESCRIPTION
本家プルリク 5050 を参照